### PR TITLE
Allow .pem file to be imported

### DIFF
--- a/modules/org/infinispan/runtime/added/bin/init_fips_keystore.sh
+++ b/modules/org/infinispan/runtime/added/bin/init_fips_keystore.sh
@@ -37,7 +37,7 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 
-KEYSTORE_PATH=$1
+KEYSTORE_PATH=${1%/}
 
 if [ ! -d "$NSSDB" ]; then
   echo "Directory $NSSDB does not exist"
@@ -49,25 +49,33 @@ if [ ! -e "$NSSDB/pkcs11.txt" ]; then
   exit 1
 fi
 
+PEM_FILES=$(ls -1 "$KEYSTORE_PATH"/*.pem 2>/dev/null | wc -l)
 CERTIFICATES=$(ls -1 "$KEYSTORE_PATH"/*.crt 2>/dev/null | wc -l)
-if [ "$CERTIFICATES" != 0 ]
-then
+
+if [ "$PEM_FILES" != 0 ]; then
+  for PEM in $KEYSTORE_PATH/*.pem; do
+    NAME=$(basename "$PEM" .pem)
+    echo "Converting $NAME.pem to $NAME.p12"
+    openssl pkcs12 -export -out "$KEYSTORE_PATH/$NAME.p12" -in "$CRT" -name "$NAME" -password "pass:$KEYSTORE_SECRET"
+  done
+fi
+
+if [ "$CERTIFICATES" != 0 ]; then
   for CRT in $KEYSTORE_PATH/*.crt; do
     NAME=$(basename "$CRT" .crt)
     echo "Converting $NAME.crt/$NAME.key to $NAME.p12"
     openssl pkcs12 -export -out "$KEYSTORE_PATH/$NAME.p12" -inkey "$KEYSTORE_PATH/$NAME.key" -in "$CRT" -name "$NAME" -password "pass:$KEYSTORE_SECRET"
   done
-else
-  if [ "$#" -ne 2 ]; then
-    echo "Importing PKCS#12 certificates requires passing the password"
-    exit 1
-  fi
-  KEYSTORE_SECRET=$2
+fi
+
+if [ "$PEM_FILES" == 0 ] && [ "$CERTIFICATES" == 0 ] && [ "${KEYSTORE_SECRET}x" == "x" ]; then
+  echo "Importing PKCS#12 certificates requires passing the password"
+  exit 1
 fi 
 
 for P12 in $KEYSTORE_PATH/*.p12; do
   echo "Importing $P12"
-  if ! pk12util -i "$P12" -d "$NSSDB" -W "$KEYSTORE_SECRET"; then
+  if ! pk12util -i "$P12" -d "$NSSDB" -W "$KEYSTORE_SECRET" -K "$KEYSTORE_SECRET"; then
     echo "An error occurred. Aborting."
     exit 1
   fi


### PR DESCRIPTION
Keeping the .crt and .key in the .pem file already created by the Operator greatly simplifies the volume/secret mount logic and keeps the Fips enabled/disabled code much closer.